### PR TITLE
scenario outline styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Scenario outline styling - Examples changed to H3 and aligned with steps
+
 
 ## [19.2.0] - 2022-03-25
 ### Added

--- a/src/components/gherkin/Examples.module.scss
+++ b/src/components/gherkin/Examples.module.scss
@@ -1,0 +1,3 @@
+.example {
+    margin-left: 1rem;
+}

--- a/src/components/gherkin/Examples.tsx
+++ b/src/components/gherkin/Examples.tsx
@@ -3,12 +3,11 @@ import React from 'react'
 import { DefaultComponent, ExamplesProps, useCustomRendering } from '../customise'
 import { Children } from './Children'
 import { Description } from './Description'
+import defaultStyles from './Examples.module.scss'
 import { ExamplesTable } from './ExamplesTable'
 import { Keyword } from './Keyword'
 import { Tags } from './Tags'
 import { Title } from './Title'
-import defaultStyles from './Examples.module.scss'
-
 
 const DefaultRenderer: DefaultComponent<ExamplesProps> = ({ examples, styles }) => {
   return (
@@ -29,6 +28,10 @@ const DefaultRenderer: DefaultComponent<ExamplesProps> = ({ examples, styles }) 
 }
 
 export const Examples: React.FunctionComponent<ExamplesProps> = (props) => {
-  const ResolvedRenderer = useCustomRendering<ExamplesProps>('Examples', defaultStyles, DefaultRenderer)
+  const ResolvedRenderer = useCustomRendering<ExamplesProps>(
+    'Examples',
+    defaultStyles,
+    DefaultRenderer
+  )
   return <ResolvedRenderer {...props} />
 }

--- a/src/components/gherkin/Examples.tsx
+++ b/src/components/gherkin/Examples.tsx
@@ -7,12 +7,14 @@ import { ExamplesTable } from './ExamplesTable'
 import { Keyword } from './Keyword'
 import { Tags } from './Tags'
 import { Title } from './Title'
+import defaultStyles from './Examples.module.scss'
 
-const DefaultRenderer: DefaultComponent<ExamplesProps> = ({ examples }) => {
+
+const DefaultRenderer: DefaultComponent<ExamplesProps> = ({ examples, styles }) => {
   return (
-    <section>
+    <section className={styles.example}>
       <Tags tags={examples.tags} />
-      <Title header="h2" id={examples.id}>
+      <Title header="h3" id={examples.id}>
         <Keyword>{examples.keyword}:</Keyword>
         <span>{examples.name}</span>
       </Title>
@@ -27,6 +29,6 @@ const DefaultRenderer: DefaultComponent<ExamplesProps> = ({ examples }) => {
 }
 
 export const Examples: React.FunctionComponent<ExamplesProps> = (props) => {
-  const ResolvedRenderer = useCustomRendering<ExamplesProps>('Examples', {}, DefaultRenderer)
+  const ResolvedRenderer = useCustomRendering<ExamplesProps>('Examples', defaultStyles, DefaultRenderer)
   return <ResolvedRenderer {...props} />
 }


### PR DESCRIPTION
### 🤔 What's changed?

* "Scenario Outline" and "Examples" both are H2 tags. I suggest using H3 for "Examples".
* Align "Examples" with steps (move it slightly to the right)

### ⚡️ What's your motivation? 

Fixes #130.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- UI change.

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
